### PR TITLE
Исправил ошибку при запуске bootstrap.in-up.sh

### DIFF
--- a/bootstrap.in-up.sh
+++ b/bootstrap.in-up.sh
@@ -71,4 +71,11 @@ echo "Получаю изменения шаблона - без помещени
 echo "(Для отката используйте команду 'git checkout .')"
 
 # Добавляем параметр --allow-unrelated-histories чтобы учесть новое поведение git (воспроизводилось на 2.9.3.windows.1) при слиянии репозиториев 
-git pull --no-tags --no-commit --allow-unrelated-histories vanessa-bootstrap master
+GIT_VER=$(git --version)
+if [[ "$GIT_VER" > "2.9" ]]; then
+    AUH_PARAM="--allow-unrelated-histories" 
+else 
+    AUH_PARAM=""
+fi
+
+git pull --no-tags --no-commit "$AUH_PARAM" vanessa-bootstrap master

--- a/bootstrap.in-up.sh
+++ b/bootstrap.in-up.sh
@@ -4,6 +4,11 @@ echo "Инсталятор и обновлятор шаблона разрабо
 echo "Vanessa Bootstrap Install or Upgrade"
 echo "подключает bootstrap к текущему репозиторию и обновляет его из ветки master"
 
+# Переходим в каталог GIT если он указан в параметре, если запускать скрипт из каталога git, при получении этого файла возникает ошибка. 
+if [ "$1" ]; then
+    cd $1
+fi
+
 if git rev-parse --git-dir > /dev/null 2>&1; then
   echo "Текущий каталог находится под управлением GIT - доступна возможность инсталяции и обновления"
 else
@@ -65,4 +70,5 @@ git fetch --no-tags vanessa-bootstrap
 echo "Получаю изменения шаблона - без помещения"
 echo "(Для отката используйте команду 'git checkout .')"
 
-git pull --no-tags --no-commit vanessa-bootstrap master
+# Добавляем параметр --allow-unrelated-histories чтобы учесть новое поведение git (воспроизводилось на 2.9.3.windows.1) при слиянии репозиториев 
+git pull --no-tags --no-commit --allow-unrelated-histories vanessa-bootstrap master


### PR DESCRIPTION

сделанные изменения:

-Исправил ошибку которая возникала при запуске bootstrap.in-up.sh для git 2.9.3.windows.1 при слиянии репозиториев
-Добавил возможность передавать каталог git в скрипт как параметр

Прошу добавить в проект 



…git 2.9.3.windows.1